### PR TITLE
Added MirrorTypeException as it is not catched by MirrorTypesException-c...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.war
 *.ear
 dagger-proguard-helper-processor/dagger-proguard-helper-processor.iml
+dagger-proguard-helper-processor/.idea/*
 dagger-proguard-helper-sample/dagger-proguard-helper-sample.iml
 dagger-proguard-helper-sample/dagger-proguard-keepnames.cfg
 dagger-proguard-keepnames.cfg

--- a/dagger-proguard-helper-processor/pom.xml
+++ b/dagger-proguard-helper-processor/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.squareup.dagger</groupId>
             <artifactId>dagger</artifactId>
-            <version>1.0.1</version>
+            <version>1.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/dagger-proguard-helper-processor/pom.xml
+++ b/dagger-proguard-helper-processor/pom.xml
@@ -5,18 +5,15 @@
 
     <name>Dagger Proguard Helper Processor</name>
 
+    <groupId>com.github.idamobile</groupId>
     <artifactId>dagger-proguard-helper-processor</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-
-    <parent>
-        <groupId>com.github.idamobile</groupId>
-        <artifactId>dagger-proguard-helper</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- github server corresponds to entry in ~/.m2/settings.xml -->
+        <github.global.server>github</github.global.server>
     </properties>
 
     <dependencies>
@@ -28,6 +25,14 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>
@@ -35,6 +40,36 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.9</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
+                    <noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory> <!-- matches distribution management repository url above -->
+                    <branch>refs/heads/mvn-repo</branch>                       <!-- remote branch name -->
+                    <includes><include>**/*</include></includes>
+                    <repositoryName>dagger-proguard-helper</repositoryName>      <!-- github repo name -->
+                    <repositoryOwner>Plinzen</repositoryOwner>    <!-- github username  -->
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
I got the following exception from one of our customers:
javax.lang.model.type.MirroredTypeException: Attempt to access Class object for TypeMirror com.wetter.androidclient.WeatherApplication
    at com.sun.tools.javac.model.AnnotationProxyMaker$MirroredTypeExceptionProxy.generateException(AnnotationProxyMaker.java:282)
    at sun.reflect.annotation.AnnotationInvocationHandler.invoke(AnnotationInvocationHandler.java:55)
    at com.sun.proxy.$Proxy63.injects(Unknown Source)
    at com.idamobile.dagger.helper.DaggerModulesProcessor.process(DaggerModulesProcessor.java:54)

It seems to be that MirroredTypeException seems to inherits MirroredTypesException in Java 7 but not in Java 6.
